### PR TITLE
Fix changelog regex in tag script

### DIFF
--- a/scripts/tag-and-push.mjs
+++ b/scripts/tag-and-push.mjs
@@ -88,7 +88,7 @@ if (!skipChangelog) {
   const changes = fs.readFileSync(changesPath, 'utf-8');
 
   // Strict regex match: line must start with ## followed by optional v, then exact version
-  const versionRegex = new RegExp(`^##\\s+v?\\b${version.replace(/\./g, '\\.')}\\b`, 'm');
+  const versionRegex = new RegExp(`^##\\s+v?${version.replace(/\./g, '\\.')}\\b`, 'm');
   if (!versionRegex.test(changes)) {
     console.error(`❌ No entry for ${tag} found in ${changesPath}`);
     console.error(`   Please add a changelog entry first (or use --skip-changelog):\n`);

--- a/zotero-plugin.config.ts
+++ b/zotero-plugin.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
   xpiDownloadLink: `https://github.com/ub-unibe-ch/zotero-swissbib-bb-locations/releases/download/v{{version}}/zotero-swisscovery-ubbern-locations-{{version}}.xpi`,
 
   release: {
+    github: {
+      releaseNote: () => "See [CHANGES.md](https://github.com/ub-unibe-ch/zotero-swissbib-bb-locations/blob/master/CHANGES.md) for details.",
+    },
     hooks: {
       "release:init": async (ctx) => {
         // Check for uncommitted changes

--- a/zotero-plugin.config.ts
+++ b/zotero-plugin.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
 
   release: {
     github: {
-      releaseNote: () => "See [CHANGES.md](https://github.com/ub-unibe-ch/zotero-swissbib-bb-locations/blob/master/CHANGES.md) for details.",
+      releaseNote: () => `See [CHANGES.md](https://github.com/ub-unibe-ch/zotero-swissbib-bb-locations/blob/v${pkg.version}/CHANGES.md) for details.`,
     },
     hooks: {
       "release:init": async (ctx) => {


### PR DESCRIPTION
The \b word boundary between v? and the version number prevented matching entries like "## v0.3.1" because there is no word boundary between "v" and "0".
Also adds a `releaseNote` configuration.