### PR TITLE
Add fallback for prefs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Änderungen
 
+## v0.3.2
+- Bugfix: Fallback-Defaults für Preferences, wenn Zotero die Defaults aus prefs.js beim Update nicht lädt
+
 ## v0.3.1
 - Bugfix: Preference-Handling
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "Zotero/Jurism-Plugin zur Bestandsabfrage im Swisscovery UB Bern",
 
     "config": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "jest": {
         "testMatch": [
             "**/tests/**/*.test.js"
+        ],
+        "setupFiles": [
+            "./tests/jest.setup.js"
         ]
     },
     "dependencies": {

--- a/src/swisscoveryubbernlocations.js
+++ b/src/swisscoveryubbernlocations.js
@@ -1,6 +1,6 @@
 // Preference utility wrapper
 const PREFS_PREFIX = "extensions.swisscoveryubbernlocations.";
-const DEFAULTS = __PREF_DEFAULTS__;
+const DEFAULTS = globalThis.__PREF_DEFAULTS__ || {};
 
 const Pref = {
   get(key) {

--- a/src/swisscoveryubbernlocations.js
+++ b/src/swisscoveryubbernlocations.js
@@ -1,9 +1,14 @@
 // Preference utility wrapper
 const PREFS_PREFIX = "extensions.swisscoveryubbernlocations.";
+const DEFAULTS = __PREF_DEFAULTS__;
 
 const Pref = {
   get(key) {
-    return Zotero.Prefs.get(PREFS_PREFIX + key, true);
+    try {
+      return Zotero.Prefs.get(PREFS_PREFIX + key, true) ?? DEFAULTS[key];
+    } catch (e) {
+      return DEFAULTS[key];
+    }
   },
   set(key, value) {
     Zotero.Prefs.set(PREFS_PREFIX + key, value, true);

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -1,0 +1,7 @@
+const fs = require("fs");
+const prefsContent = fs.readFileSync("addon/prefs.js", "utf-8");
+const prefDefaults = {};
+for (const m of prefsContent.matchAll(/pref\("(\w+)",\s*"([^"]*)"\)/g)) {
+  prefDefaults[m[1]] = m[2];
+}
+globalThis.__PREF_DEFAULTS__ = prefDefaults;

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -1,7 +1,37 @@
+// Parse prefs.js to extract default values for Jest test runs.
+// Support the primitive preference value types accepted by Zotero/Firefox
+// and fail fast on unsupported pref declarations to avoid silently running
+// tests with incomplete defaults.
 const fs = require("fs");
 const prefsContent = fs.readFileSync("addon/prefs.js", "utf-8");
 const prefDefaults = {};
-for (const m of prefsContent.matchAll(/pref\("(\w+)",\s*"([^"]*)"\)/g)) {
-  prefDefaults[m[1]] = m[2];
+const prefLineRegex =
+  /^\s*pref\("([^"]+)",\s*(?:"([^"]*)"|(true|false)|(-?\d+(?:\.\d+)?))\s*\);\s*$/;
+
+for (const line of prefsContent.split(/\r?\n/)) {
+  const trimmedLine = line.trim();
+
+  if (!trimmedLine || trimmedLine.startsWith("//")) {
+    continue;
+  }
+
+  const match = trimmedLine.match(prefLineRegex);
+  if (match) {
+    const [, key, stringValue, booleanValue, numberValue] = match;
+
+    if (stringValue !== undefined) {
+      prefDefaults[key] = stringValue;
+    } else if (booleanValue !== undefined) {
+      prefDefaults[key] = booleanValue === "true";
+    } else if (numberValue !== undefined) {
+      prefDefaults[key] = Number(numberValue);
+    }
+
+    continue;
+  }
+
+  if (trimmedLine.startsWith('pref("')) {
+    throw new Error(`Unsupported preference declaration in addon/prefs.js: ${trimmedLine}`);
+  }
 }
 globalThis.__PREF_DEFAULTS__ = prefDefaults;

--- a/tests/prefDefaults.test.js
+++ b/tests/prefDefaults.test.js
@@ -1,0 +1,53 @@
+describe("Pref defaults fallback", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test("should return defaults when Zotero.Prefs.get returns undefined", () => {
+    global.Zotero = {
+      Prefs: {
+        get: () => undefined,
+      },
+      debug: console.log,
+    };
+    const SUL = require("../src/swisscoveryubbernlocations");
+    expect(SUL.sruPrefix).toContain("slsp-ube.alma.exlibrisgroup.com");
+    expect(SUL.apiKey).toBe("");
+    expect(SUL.targetField).toBe("abstractNote");
+  });
+
+  test("should return defaults when Zotero.Prefs.get throws", () => {
+    global.Zotero = {
+      Prefs: {
+        get: () => {
+          throw new Error("pref not found");
+        },
+      },
+      debug: console.log,
+    };
+    const SUL = require("../src/swisscoveryubbernlocations");
+    expect(SUL.sruPrefix).toContain("slsp-ube.alma.exlibrisgroup.com");
+    expect(SUL.apiKey).toBe("");
+    expect(SUL.targetField).toBe("abstractNote");
+  });
+
+  test("should prefer user-set values over defaults", () => {
+    global.Zotero = {
+      Prefs: {
+        get: (pref) => {
+          const prefs = {
+            "extensions.swisscoveryubbernlocations.sruurl": "http://custom.example.com/sru",
+            "extensions.swisscoveryubbernlocations.apikey": "my-key",
+            "extensions.swisscoveryubbernlocations.targetField": "extra",
+          };
+          return prefs[pref];
+        },
+      },
+      debug: console.log,
+    };
+    const SUL = require("../src/swisscoveryubbernlocations");
+    expect(SUL.sruPrefix).toBe("http://custom.example.com/sru");
+    expect(SUL.apiKey).toBe("my-key");
+    expect(SUL.targetField).toBe("extra");
+  });
+});

--- a/zotero-plugin.config.ts
+++ b/zotero-plugin.config.ts
@@ -6,11 +6,40 @@ import fs from "fs";
 
 
 
-// Parse prefs.js to extract default values for build-time injection
+// Parse prefs.js to extract default values for build-time injection.
+// Support the primitive preference value types accepted by Zotero/Firefox
+// and fail fast on unsupported pref declarations to avoid silently building
+// with incomplete defaults.
 const prefsContent = fs.readFileSync("addon/prefs.js", "utf-8");
-const prefDefaults: Record<string, string> = {};
-for (const m of prefsContent.matchAll(/pref\("(\w+)",\s*"([^"]*)"\)/g)) {
-  prefDefaults[m[1]] = m[2];
+const prefDefaults: Record<string, string | number | boolean> = {};
+const prefLineRegex =
+  /^\s*pref\("([^"]+)",\s*(?:"([^"]*)"|(true|false)|(-?\d+(?:\.\d+)?))\s*\);\s*$/;
+
+for (const line of prefsContent.split(/\r?\n/)) {
+  const trimmedLine = line.trim();
+
+  if (!trimmedLine || trimmedLine.startsWith("//")) {
+    continue;
+  }
+
+  const match = trimmedLine.match(prefLineRegex);
+  if (match) {
+    const [, key, stringValue, booleanValue, numberValue] = match;
+
+    if (stringValue !== undefined) {
+      prefDefaults[key] = stringValue;
+    } else if (booleanValue !== undefined) {
+      prefDefaults[key] = booleanValue === "true";
+    } else if (numberValue !== undefined) {
+      prefDefaults[key] = Number(numberValue);
+    }
+
+    continue;
+  }
+
+  if (trimmedLine.startsWith('pref("')) {
+    throw new Error(`Unsupported preference declaration in addon/prefs.js: ${trimmedLine}`);
+  }
 }
 
 export default defineConfig({
@@ -70,7 +99,7 @@ export default defineConfig({
         entryPoints: ["src/swisscoveryubbernlocations.js"],
         define: {
           __env__: `"${process.env.NODE_ENV}"`,
-          __PREF_DEFAULTS__: JSON.stringify(prefDefaults),
+          "globalThis.__PREF_DEFAULTS__": JSON.stringify(prefDefaults),
         },
         bundle: true,
         target: "firefox115",

--- a/zotero-plugin.config.ts
+++ b/zotero-plugin.config.ts
@@ -6,6 +6,13 @@ import fs from "fs";
 
 
 
+// Parse prefs.js to extract default values for build-time injection
+const prefsContent = fs.readFileSync("addon/prefs.js", "utf-8");
+const prefDefaults: Record<string, string> = {};
+for (const m of prefsContent.matchAll(/pref\("(\w+)",\s*"([^"]*)"\)/g)) {
+  prefDefaults[m[1]] = m[2];
+}
+
 export default defineConfig({
   dist: ".scaffold/build",
   source: ["src", "addon"],
@@ -63,6 +70,7 @@ export default defineConfig({
         entryPoints: ["src/swisscoveryubbernlocations.js"],
         define: {
           __env__: `"${process.env.NODE_ENV}"`,
+          __PREF_DEFAULTS__: JSON.stringify(prefDefaults),
         },
         bundle: true,
         target: "firefox115",


### PR DESCRIPTION
Currently, Zotero doesn't load the default prefs correctly. Until this gets fixed, we need an explicit fallback.