### PR TITLE
Add debug mode for order notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Änderungen
 
+## v0.3.3
+- Feature: Debug-Modus mit Zeitstempel für Bestellnotizen
+- Feature: Funktion zum Löschen von Bestellnotizen (im Debug-Modus)
+- Verbesserung: Validierung und Logging für Bestellnotizen
+- Verbesserung: Batch-Speicherung über Zotero.DB.executeTransaction
+
 ## v0.3.2
 - Bugfix: Fallback-Defaults für Preferences, wenn Zotero die Defaults aus prefs.js beim Update nicht lädt
 

--- a/addon/content/prefs.xhtml
+++ b/addon/content/prefs.xhtml
@@ -4,6 +4,9 @@
         <html:input type="text" preference="apikey"/>
 	</groupbox>
     <groupbox>
+        <checkbox preference="debug" data-l10n-id="preferences-debug"/>
+    </groupbox>
+    <groupbox>
         <label><html:h2>Zielfeld</html:h2></label>
         <radiogroup preference="targetField" id="somePreference">
             <radio data-l10n-id="preferences-abstractNote" value="abstractNote"/>

--- a/addon/locale/de/ubbernlocations.ftl
+++ b/addon/locale/de/ubbernlocations.ftl
@@ -16,5 +16,8 @@ preferences-extra =
 preferences-apiKey =
     .label = Api-Key für Alma
 
+itemmenu-clearOrderNotes =
+    .label = Bestellnotizen löschen (Debug)
+
 preferences-debug =
     .label = Debug-Modus (Zeitstempel an Einträge anhängen)

--- a/addon/locale/de/ubbernlocations.ftl
+++ b/addon/locale/de/ubbernlocations.ftl
@@ -15,3 +15,6 @@ preferences-extra =
 
 preferences-apiKey =
     .label = Api-Key für Alma
+
+preferences-debug =
+    .label = Debug-Modus (Zeitstempel an Einträge anhängen)

--- a/addon/locale/en-US/ubbernlocations.ftl
+++ b/addon/locale/en-US/ubbernlocations.ftl
@@ -15,3 +15,6 @@ preferences-extra =
 
 preferences-apiKey =
     .label = API Key for Alma
+
+preferences-debug =
+    .label = Debug mode (append timestamps to entries)

--- a/addon/locale/en-US/ubbernlocations.ftl
+++ b/addon/locale/en-US/ubbernlocations.ftl
@@ -16,5 +16,8 @@ preferences-extra =
 preferences-apiKey =
     .label = API Key for Alma
 
+itemmenu-clearOrderNotes =
+    .label = Clear order notes (Debug)
+
 preferences-debug =
     .label = Debug mode (append timestamps to entries)

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -1,3 +1,4 @@
 pref("apikey", "");
 pref("sruurl", "https://slsp-ube.alma.exlibrisgroup.com/view/sru/41SLSP_UBE?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=alma.isbn=");
 pref("targetField", "abstractNote");
+pref("debug", false);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3.2",
+    "version": "0.3.3",
     "description": "Zotero/Jurism-Plugin zur Bestandsabfrage im Swisscovery UB Bern",
 
     "config": {

--- a/src/swisscoveryubbernlocations.js
+++ b/src/swisscoveryubbernlocations.js
@@ -165,14 +165,30 @@ SUL = {
       const items = selectedItems.filter(
         (item) => item.itemTypeID === Zotero.ItemTypes.getID("book")
       );
-      for (const item of items) {
+      SUL.log(`addOrderNote: processing ${items.length} items`);
+      for (const [i, item] of items.entries()) {
+        const title = item.getField("title");
         const tags = item.getTags();
+        SUL.log(`addOrderNote [${i + 1}/${items.length}] "${title}": ${tags.length} tags`);
         const { ddcs, orderCodes, budgetCode } = SUL.orderNote.extractTags(tags);
-        let orderNote = SUL.orderNote.constructOrderNote({ ddcs, orderCodes, budgetCode });
-        if (Pref.debug) {
-          orderNote += ` [${new Date().toLocaleString()}]`;
+        SUL.log(`addOrderNote [${i + 1}/${items.length}] ETAT="${budgetCode}" DDC=[${ddcs}] BC=[${orderCodes}]`);
+
+        const missing = [];
+        if (!budgetCode) missing.push("ETAT");
+        if (!ddcs.length) missing.push("DDC");
+
+        let value;
+        if (missing.length) {
+          value = `⚠ FEHLT: ${missing.join(", ")}`;
+        } else {
+          value = SUL.orderNote.constructOrderNote({ ddcs, orderCodes, budgetCode });
         }
-        item.setField("volume", orderNote);
+        if (Pref.debug) {
+          value += ` [${new Date().toLocaleString()}]`;
+        }
+        SUL.log(`addOrderNote [${i + 1}/${items.length}] result: "${value}"`);
+
+        item.setField("volume", value);
         await item.saveTx();
       }
     },

--- a/src/swisscoveryubbernlocations.js
+++ b/src/swisscoveryubbernlocations.js
@@ -16,6 +16,7 @@ const Pref = {
   get sruurl() { return this.get("sruurl"); },
   get apikey() { return this.get("apikey"); },
   get targetField() { return this.get("targetField"); },
+  get debug() { return this.get("debug"); },
 };
 
 SUL = {
@@ -159,7 +160,10 @@ SUL = {
       for (const item of items) {
         const tags = item.getTags();
         const { ddcs, orderCodes, budgetCode } = SUL.orderNote.extractTags(tags);
-        const orderNote = SUL.orderNote.constructOrderNote({ ddcs, orderCodes, budgetCode });
+        let orderNote = SUL.orderNote.constructOrderNote({ ddcs, orderCodes, budgetCode });
+        if (Pref.debug) {
+          orderNote += ` [${new Date().toLocaleString()}]`;
+        }
         item.setField("volume", orderNote);
         await item.saveTx();
       }

--- a/src/swisscoveryubbernlocations.js
+++ b/src/swisscoveryubbernlocations.js
@@ -166,31 +166,33 @@ SUL = {
         (item) => item.itemTypeID === Zotero.ItemTypes.getID("book")
       );
       SUL.log(`addOrderNote: processing ${items.length} items`);
-      for (const [i, item] of items.entries()) {
-        const title = item.getField("title");
-        const tags = item.getTags();
-        SUL.log(`addOrderNote [${i + 1}/${items.length}] "${title}": ${tags.length} tags`);
-        const { ddcs, orderCodes, budgetCode } = SUL.orderNote.extractTags(tags);
-        SUL.log(`addOrderNote [${i + 1}/${items.length}] ETAT="${budgetCode}" DDC=[${ddcs}] BC=[${orderCodes}]`);
+      await Zotero.DB.executeTransaction(async () => {
+        for (const [i, item] of items.entries()) {
+          const title = item.getField("title");
+          const tags = item.getTags();
+          SUL.log(`addOrderNote [${i + 1}/${items.length}] "${title}": ${tags.length} tags`);
+          const { ddcs, orderCodes, budgetCode } = SUL.orderNote.extractTags(tags);
+          SUL.log(`addOrderNote [${i + 1}/${items.length}] ETAT="${budgetCode}" DDC=[${ddcs}] BC=[${orderCodes}]`);
 
-        const missing = [];
-        if (!budgetCode) missing.push("ETAT");
-        if (!ddcs.length) missing.push("DDC");
+          const missing = [];
+          if (!budgetCode) missing.push("ETAT");
+          if (!ddcs.length) missing.push("DDC");
 
-        let value;
-        if (missing.length) {
-          value = `⚠ FEHLT: ${missing.join(", ")}`;
-        } else {
-          value = SUL.orderNote.constructOrderNote({ ddcs, orderCodes, budgetCode });
+          let value;
+          if (missing.length) {
+            value = `⚠ FEHLT: ${missing.join(", ")}`;
+          } else {
+            value = SUL.orderNote.constructOrderNote({ ddcs, orderCodes, budgetCode });
+          }
+          if (Pref.debug) {
+            value += ` [${new Date().toLocaleString()}]`;
+          }
+          SUL.log(`addOrderNote [${i + 1}/${items.length}] result: "${value}"`);
+
+          item.setField("volume", value);
+          await item.save();
         }
-        if (Pref.debug) {
-          value += ` [${new Date().toLocaleString()}]`;
-        }
-        SUL.log(`addOrderNote [${i + 1}/${items.length}] result: "${value}"`);
-
-        item.setField("volume", value);
-        await item.saveTx();
-      }
+      });
     },
 
     async clearOrderNotes() {
@@ -199,10 +201,12 @@ SUL = {
       const items = selectedItems.filter(
         (item) => item.itemTypeID === Zotero.ItemTypes.getID("book")
       );
-      for (const item of items) {
-        item.setField("volume", "");
-        await item.saveTx();
-      }
+      await Zotero.DB.executeTransaction(async () => {
+        for (const item of items) {
+          item.setField("volume", "");
+          await item.save();
+        }
+      });
       SUL.log(`clearOrderNotes: cleared ${items.length} items`);
     },
 

--- a/src/swisscoveryubbernlocations.js
+++ b/src/swisscoveryubbernlocations.js
@@ -99,6 +99,14 @@ SUL = {
       command: this.orderNote.addOrderNote.bind(this),
       dataL10nId: "zoteroswisscoveryubbernlocations-itemmenu-orderNoteToAbstract",
     });
+
+    if (Pref.debug) {
+      this.createMenuItem(doc, this.popup, {
+        id: "submenuitem3",
+        command: this.orderNote.clearOrderNotes.bind(this),
+        dataL10nId: "zoteroswisscoveryubbernlocations-itemmenu-clearOrderNotes",
+      });
+    }
   },
 
   createMenuItem(doc, parent, { id, command, dataL10nId }) {
@@ -167,6 +175,19 @@ SUL = {
         item.setField("volume", orderNote);
         await item.saveTx();
       }
+    },
+
+    async clearOrderNotes() {
+      const ZoteroPane = Zotero.getActiveZoteroPane();
+      const selectedItems = ZoteroPane.getSelectedItems();
+      const items = selectedItems.filter(
+        (item) => item.itemTypeID === Zotero.ItemTypes.getID("book")
+      );
+      for (const item of items) {
+        item.setField("volume", "");
+        await item.saveTx();
+      }
+      SUL.log(`clearOrderNotes: cleared ${items.length} items`);
     },
 
     extractTags(tags) {

--- a/updates.json
+++ b/updates.json
@@ -9,7 +9,7 @@
           "applications": {
             "zotero": {
               "strict_min_version": "6.999",
-              "strict_max_version": "8.*"
+              "strict_max_version": "9.*"
             }
           }
         }


### PR DESCRIPTION
- Debug-Modus als Preference (Boolean) in den Einstellungen                                 
- Zeitstempel in Bestellnotizen im Debug-Modus                                              
- "Bestellnotizen löschen"-Funktion im Kontextmenü (nur im Debug-Modus)                     
- Validierung und Logging für Bestellnotizen                                                
- Batch-Speicherung über Zotero.DB.executeTransaction      