### PR TITLE
Menu refactor zotero8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ typings/
 # Reference/template directories
 zotero-plugin-template/
 .claude/
+
+# Local work plans (not shared)
+.plans/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Änderungen
 
+## v0.4.0
+- **Breaking**: Zotero 7 wird nicht mehr unterstützt (`strict_min_version = "8.0"`)
+- Menüregistrierung auf `Zotero.MenuManager` umgestellt (deklarativ, fenster­übergreifend, automatisches Cleanup)
+- Debug-Menüpunkt „Bestellnotizen löschen" schaltet sich zur Laufzeit über die Debug-Pref um — kein Plugin-Restart mehr nötig
+
 ## v0.3.4
 - Zotero 9 Kompatibilität
 

--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -32,8 +32,8 @@ async function startup({ id, version, rootURI }) {
 			if (win.ZoteroPane) SUL.ensureFTL(win);
 		}
 	} catch (error) {
-		this.log("Error during startup");
-		this.log(error);
+		log("Error during startup");
+		log(error);
 	}
 }
 
@@ -41,8 +41,8 @@ function onMainWindowLoad({ window }) {
 	try {
 		SUL.ensureFTL(window);
 	} catch (error) {
-		this.log("Error while loading main window");
-		this.log(error);
+		log("Error while loading main window");
+		log(error);
 	}
 }
 
@@ -52,8 +52,8 @@ function shutdown() {
 		SUL.unregisterMenu();
 		SUL = undefined;
 	} catch (error) {
-		this.log("Error while shutting down");
-		this.log(error);
+		log("Error while shutting down");
+		log(error);
 	}
 }
 
@@ -61,7 +61,7 @@ function uninstall() {
 	try {
 		log("Uninstalled");
 	} catch (error) {
-		this.log("Error while uninstalling");
-		this.log(error);
+		log("Error while uninstalling");
+		log(error);
 	}
 }

--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -25,9 +25,12 @@ async function startup({ id, version, rootURI }) {
 		});
 		
 		Services.scriptloader.loadSubScript(rootURI + 'swisscoveryubbernlocations.js');
-		
+
 		SUL.init({ id, version, rootURI });
-		SUL.addToAllWindows();
+		SUL.registerMenu();
+		for (const win of Zotero.getMainWindows()) {
+			if (win.ZoteroPane) SUL.ensureFTL(win);
+		}
 	} catch (error) {
 		this.log("Error during startup");
 		this.log(error);
@@ -36,18 +39,9 @@ async function startup({ id, version, rootURI }) {
 
 function onMainWindowLoad({ window }) {
 	try {
-		SUL.addToWindow(window);
+		SUL.ensureFTL(window);
 	} catch (error) {
 		this.log("Error while loading main window");
-		this.log(error);
-	}
-}
-
-function onMainWindowUnload({ window }) {
-	try {
-		SUL.removeFromWindow(window);
-	} catch (error) {
-		this.log("Error while unloading main window");
 		this.log(error);
 	}
 }
@@ -55,7 +49,7 @@ function onMainWindowUnload({ window }) {
 function shutdown() {
 	try {
 		log("Shutting down");
-		SUL.removeFromAllWindows();
+		SUL.unregisterMenu();
 		SUL = undefined;
 	} catch (error) {
 		this.log("Error while shutting down");

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -13,7 +13,7 @@
     "zotero": {
       "id": "__addonID__",
       "update_url": "__updateURL__",
-      "strict_min_version": "6.999",
+      "strict_min_version": "8.0",
       "strict_max_version": "9.*"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3.4",
+    "version": "0.4.0",
     "description": "Zotero/Jurism-Plugin zur Bestandsabfrage im Swisscovery UB Bern",
 
     "config": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,10 @@
     "pnpm": {
         "overrides": {
             "minimatch@3.1": "^3.1.3",
-            "minimatch@9.0": "^9.0.7"
+            "minimatch@9.0": "^9.0.7",
+            "defu": "^6.1.5",
+            "picomatch@2": "^2.3.2",
+            "picomatch@4": "^4.0.4"
         }
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 overrides:
   minimatch@3.1: ^3.1.3
   minimatch@9.0: ^9.0.7
+  defu: ^6.1.5
+  picomatch@2: ^2.3.2
+  picomatch@4: ^4.0.4
 
 importers:
 
@@ -1103,8 +1106,8 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1213,7 +1216,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: ^4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -1728,12 +1731,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pirates@4.0.7:
@@ -2960,7 +2963,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   argparse@1.0.10:
     dependencies:
@@ -3079,7 +3082,7 @@ snapshots:
     dependencies:
       chokidar: 5.0.0
       confbox: 0.2.4
-      defu: 6.1.4
+      defu: 6.1.7
       dotenv: 17.2.4
       exsolve: 1.0.8
       giget: 2.0.0
@@ -3182,7 +3185,7 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
-  defu@6.1.4: {}
+  defu@6.1.7: {}
 
   delayed-stream@1.0.0: {}
 
@@ -3299,9 +3302,9 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fill-range@7.1.1:
     dependencies:
@@ -3368,7 +3371,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       node-fetch-native: 1.6.7
       nypm: 0.6.5
       pathe: 2.0.3
@@ -3768,7 +3771,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   jest-validate@30.2.0:
     dependencies:
@@ -3891,7 +3894,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -4007,9 +4010,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
 
@@ -4041,7 +4044,7 @@ snapshots:
 
   rc9@2.1.2:
     dependencies:
-      defu: 6.1.4
+      defu: 6.1.7
       destr: 2.0.5
 
   react-is@18.3.1: {}
@@ -4160,8 +4163,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tmpl@1.0.5: {}
 

--- a/src/swisscoveryubbernlocations.js
+++ b/src/swisscoveryubbernlocations.js
@@ -24,7 +24,8 @@ SUL = {
   version: null,
   rootURI: null,
   initialized: false,
-  addedElementIDs: [],
+  menuID: null,
+  ftlFilename: "zoteroswisscoveryubbernlocations-ubbernlocations.ftl",
 
   init({ id, version, rootURI }) {
     if (this.initialized) return;
@@ -67,87 +68,48 @@ SUL = {
     Zotero.debug("[ Swisscovery UB Bern Locations ] : " + msg);
   },
 
-  addToWindow(window) {
-    let doc = window.document;
+  ensureFTL(window) {
+    if (!window?.MozXULElement) return;
+    window.MozXULElement.insertFTLIfNeeded(this.ftlFilename);
+  },
 
-    // Use Fluent for localization
-    window.MozXULElement.insertFTLIfNeeded("zoteroswisscoveryubbernlocations-ubbernlocations.ftl");
-
-    // Add a submenu to the item menu
-    this.submenu = doc.createXULElement("menu");
-    this.submenu.id = "SUL_submenu";
-    this.submenu.setAttribute("type", "menu");
-    this.submenu.setAttribute("class", "menuitem-iconic");
-    this.submenu.setAttribute("image", this.rootURI + "content/icons/glass_48.png");
-    this.submenu.setAttribute("data-l10n-id", "zoteroswisscoveryubbernlocations-itemmenu-submenu");
-    doc.getElementById("zotero-itemmenu").appendChild(this.submenu);
-    this.storeAddedElement(this.submenu);
-
-    // Add a menu popup
-    this.popup = this.submenu.appendChild(doc.createXULElement("menupopup"));
-    this.popup.id = "my_popup";
-    this.storeAddedElement(this.popup);
-
-    this.createMenuItem(doc, this.popup, {
-      id: "submenuitem",
-      command: this.locationLookup.LocationLookup.bind(this),
-      dataL10nId: "zoteroswisscoveryubbernlocations-itemmenu-locationlookup",
+  registerMenu() {
+    this.menuID = Zotero.MenuManager.registerMenu({
+      menuID: "swisscoveryubbernlocations-itemmenu",
+      pluginID: this.id,
+      target: "main/library/item",
+      menus: [
+        {
+          menuType: "submenu",
+          l10nID: "zoteroswisscoveryubbernlocations-itemmenu-submenu",
+          icon: this.rootURI + "content/icons/glass_48.png",
+          menus: [
+            {
+              menuType: "menuitem",
+              l10nID: "zoteroswisscoveryubbernlocations-itemmenu-locationlookup",
+              onCommand: () => SUL.locationLookup.LocationLookup(),
+            },
+            {
+              menuType: "menuitem",
+              l10nID: "zoteroswisscoveryubbernlocations-itemmenu-orderNoteToAbstract",
+              onCommand: () => SUL.orderNote.addOrderNote(),
+            },
+            {
+              menuType: "menuitem",
+              l10nID: "zoteroswisscoveryubbernlocations-itemmenu-clearOrderNotes",
+              onShowing: (event, context) => context.setVisible(Pref.debug),
+              onCommand: () => SUL.orderNote.clearOrderNotes(),
+            },
+          ],
+        },
+      ],
     });
-
-    this.createMenuItem(doc, this.popup, {
-      id: "submenuitem2",
-      command: this.orderNote.addOrderNote.bind(this),
-      dataL10nId: "zoteroswisscoveryubbernlocations-itemmenu-orderNoteToAbstract",
-    });
-
-    if (Pref.debug) {
-      this.createMenuItem(doc, this.popup, {
-        id: "submenuitem3",
-        command: this.orderNote.clearOrderNotes.bind(this),
-        dataL10nId: "zoteroswisscoveryubbernlocations-itemmenu-clearOrderNotes",
-      });
-    }
   },
 
-  createMenuItem(doc, parent, { id, command, dataL10nId }) {
-    const menuItem = doc.createXULElement("menuitem");
-    menuItem.id = id;
-    menuItem.setAttribute("type", "command");
-    menuItem.setAttribute("class", "menuitem");
-    menuItem.setAttribute("data-l10n-id", dataL10nId);
-    menuItem.addEventListener("command", command);
-    parent.appendChild(menuItem);
-    this.storeAddedElement(menuItem);
-  },
-
-  addToAllWindows() {
-    const windows = Zotero.getMainWindows();
-    for (const win of windows) {
-      if (!win.ZoteroPane) continue;
-      this.addToWindow(win);
-    }
-  },
-
-  storeAddedElement(elem) {
-    if (!elem.id) {
-      throw new Error("Element must have an id");
-    }
-    this.addedElementIDs.push(elem.id);
-  },
-
-  removeFromWindow(window) {
-    const doc = window.document;
-    for (const id of this.addedElementIDs) {
-      doc.getElementById(id)?.remove();
-    }
-    doc.querySelector('[href="zoteroswisscoveryubbernlocations-ubbernlocations.ftl"]')?.remove();
-  },
-
-  removeFromAllWindows() {
-    const windows = Zotero.getMainWindows();
-    for (const win of windows) {
-      if (!win.ZoteroPane) continue;
-      this.removeFromWindow(win);
+  unregisterMenu() {
+    if (this.menuID) {
+      Zotero.MenuManager.unregisterMenu(this.menuID);
+      this.menuID = null;
     }
   },
 

--- a/tests/menuManager.test.js
+++ b/tests/menuManager.test.js
@@ -1,0 +1,90 @@
+describe("SUL Plugin - MenuManager registration", () => {
+  let mockRegisterMenu;
+  let mockUnregisterMenu;
+  let SUL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    mockRegisterMenu = jest.fn(() => "menu-handle-123");
+    mockUnregisterMenu = jest.fn();
+    global.Zotero = {
+      Prefs: {
+        get: () => undefined,
+      },
+      MenuManager: {
+        registerMenu: mockRegisterMenu,
+        unregisterMenu: mockUnregisterMenu,
+      },
+      debug: () => {},
+    };
+    SUL = require("../src/swisscoveryubbernlocations");
+    SUL.initialized = false;
+    SUL.init({
+      id: "zoteroswisscoveryubbernlocations@ubbe.org",
+      version: "0.4.0",
+      rootURI: "chrome://test/",
+    });
+  });
+
+  test("registerMenu calls Zotero.MenuManager.registerMenu with correct target and pluginID", () => {
+    SUL.registerMenu();
+    expect(mockRegisterMenu).toHaveBeenCalledTimes(1);
+    const config = mockRegisterMenu.mock.calls[0][0];
+    expect(config.target).toBe("main/library/item");
+    expect(config.pluginID).toBe("zoteroswisscoveryubbernlocations@ubbe.org");
+    expect(config.menuID).toBe("swisscoveryubbernlocations-itemmenu");
+  });
+
+  test("registerMenu stores returned handle for later unregistration", () => {
+    SUL.registerMenu();
+    expect(SUL.menuID).toBe("menu-handle-123");
+  });
+
+  test("registered submenu exposes LocationLookup and addOrderNote as menu items", () => {
+    SUL.registerMenu();
+    const config = mockRegisterMenu.mock.calls[0][0];
+    const submenu = config.menus[0];
+    expect(submenu.menuType).toBe("submenu");
+    const ids = submenu.menus.map((m) => m.l10nID);
+    expect(ids).toContain("zoteroswisscoveryubbernlocations-itemmenu-locationlookup");
+    expect(ids).toContain("zoteroswisscoveryubbernlocations-itemmenu-orderNoteToAbstract");
+    expect(ids).toContain("zoteroswisscoveryubbernlocations-itemmenu-clearOrderNotes");
+  });
+
+  test("clearOrderNotes menu item is hidden when debug pref is false", () => {
+    global.Zotero.Prefs.get = (key) =>
+      key === "extensions.swisscoveryubbernlocations.debug" ? false : undefined;
+    SUL.registerMenu();
+    const clearItem = mockRegisterMenu.mock.calls[0][0].menus[0].menus.find(
+      (m) => m.l10nID === "zoteroswisscoveryubbernlocations-itemmenu-clearOrderNotes"
+    );
+    const setVisible = jest.fn();
+    clearItem.onShowing({}, { setVisible });
+    expect(setVisible).toHaveBeenCalledWith(false);
+  });
+
+  test("clearOrderNotes menu item is visible when debug pref is true", () => {
+    global.Zotero.Prefs.get = (key) =>
+      key === "extensions.swisscoveryubbernlocations.debug" ? true : undefined;
+    SUL.registerMenu();
+    const clearItem = mockRegisterMenu.mock.calls[0][0].menus[0].menus.find(
+      (m) => m.l10nID === "zoteroswisscoveryubbernlocations-itemmenu-clearOrderNotes"
+    );
+    const setVisible = jest.fn();
+    clearItem.onShowing({}, { setVisible });
+    expect(setVisible).toHaveBeenCalledWith(true);
+  });
+
+  test("unregisterMenu calls Zotero.MenuManager.unregisterMenu with stored handle", () => {
+    SUL.registerMenu();
+    SUL.unregisterMenu();
+    expect(mockUnregisterMenu).toHaveBeenCalledWith("menu-handle-123");
+    expect(SUL.menuID).toBeNull();
+  });
+
+  test("unregisterMenu is a no-op when nothing is registered", () => {
+    SUL.menuID = null;
+    SUL.unregisterMenu();
+    expect(mockUnregisterMenu).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- Menüregistrierung von imperativer Per-Window-Injection auf deklaratives `Zotero.MenuManager.registerMenu` umgestellt (`target: "main/library/item"`)   — fensterübergreifend, automatisches Cleanup beim Plugin-Disable           
- Debug-Menüpunkt „Bestellnotizen löschen" schaltet sich zur Laufzeit über  `onShowing` + `Pref.debug` um (kein Plugin-Restart mehr nötig)
- **Breaking**: Zotero 7 wird nicht mehr unterstützt, `strict_min_version` auf `"8.0"` gehoben (MenuManager ist Z8-nativ)
- Version 0.3.4 → 0.4.0